### PR TITLE
Make $VERSION compatible with version.pm 

### DIFF
--- a/build-data.nanp
+++ b/build-data.nanp
@@ -32,7 +32,7 @@ print MODULE q{
   use warnings;
   use vars qw(%areanames);
 }.
-"our \$VERSION = 1.".join("", (gmtime())[5] + 1900, sprintf('%02d', (gmtime())[4] + 1), map { sprintf('%02d', $_) } (gmtime())[3, 2, 1, 0]).";\n\n".q{
+"our \$VERSION = '1.".join("", (gmtime())[5] + 1900, sprintf('%02d', (gmtime())[4] + 1), map { sprintf('%02d', $_) } (gmtime())[3, 2, 1, 0])."';\n\n".q{
 
   sub _prefixes {
       my $number = shift;


### PR DESCRIPTION
If $VERSION is a numeric literal, version.pm interprets this as a decimal format and truncates it to 6 decimal places [1] - It is generally accepted that versions should be quoted in Modern Perl

This is what causes cpan-outdated to constantly show Number::Phone as outdated. It creates a version object via Module::Metadata, which uses version.pm, resulting in a truncated version number, meaning all comparisons on that version number are incorrect.

An alternative fix would be to shorten the version number, but this works.

[1] https://metacpan.org/module/version::Internals#Decimal-Versions
