### PR TITLE
make the NXX in NPANXX optional

### DIFF
--- a/lib/Number/Phone/Country.pm
+++ b/lib/Number/Phone/Country.pm
@@ -35,7 +35,7 @@ sub phone2country_and_idd {
 
     # deal with NANP insanity
 
-    if($phone =~ m!^1(\d{3})\d{7}$!) {
+    if($phone =~ m!^1(\d{3})(\d{7})?$!) {
 
         # see http://www.cnac.ca/co_codes/co_code_status_map.htm
 	# checked 2011-07-08


### PR DESCRIPTION
Since I don't have full phone numbers, a lot of matching I try don't work because the phone regex requires both NPA and NXX digits. I've made the NXX digits optional and that makes all the difference.

I've separated this into a different pull request (and branch) for convenience.
