### PR TITLE
Unintentional UK mode

### DIFF
--- a/lib/Number/Phone.pm
+++ b/lib/Number/Phone.pm
@@ -4,7 +4,7 @@ use strict;
 
 use Scalar::Util 'blessed';
 
-use Number::Phone::Country qw(noexport uk);
+use Number::Phone::Country qw(noexport);
 use Number::Phone::StubCountry;
 
 our $VERSION = '3.0011';
@@ -203,7 +203,7 @@ sub new {
     return undef unless($country);
     if ($number =~ /^\+1/) {
         $country = "NANP";
-    } elsif ($country =~ /^(?:GG|JE|IM)$/) {
+    } elsif ($country =~ /^(?:GB|GG|JE|IM)$/) {
         $country = 'UK';
     }
     eval "use Number::Phone::$country";

--- a/lib/Number/Phone/StubCountry.pm
+++ b/lib/Number/Phone/StubCountry.pm
@@ -2,7 +2,7 @@ package Number::Phone::StubCountry;
 
 use strict;
 use warnings;
-use Number::Phone::Country qw(noexport uk);
+use Number::Phone::Country qw(noexport);
 
 use base qw(Number::Phone);
 our $VERSION = '1.1';

--- a/t/55_number-phone-country-multiple.t
+++ b/t/55_number-phone-country-multiple.t
@@ -1,0 +1,13 @@
+#!/usr/bin/perl -w
+
+use strict;
+
+use lib 't/inc';
+use fatalwarnings;
+
+use Test::More tests => 2;
+
+use Number::Phone::Country;
+
+is(Number::Phone::Country::phone2country('+47 1234 5678'),   'NO', "first of three");
+is(Number::Phone::Country::phone2country('+44 20 12345678'), 'GB', "uk not set accidentally");


### PR DESCRIPTION
In adding the Åland Islands to Finland, I discovered a bug: any use of Number::Phone or of a stub country based on Number::Phone::StubCountry sets UK mode for Number::Phone::Country (and calling phone2country on a code which has multiple resolutions will cause stub country modules to be loaded).

The first commit is a failing test; the second is a fix.

The Åland Islands - AX - will be coming in a second data update patch at some stage.

(Test 41 is failing for me on master and after this patch, on subtests 97 and 117. I haven't investigated.)