### PR TITLE
add number method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+                3.0015  Added number() method
+
 2015-12-08      3.0014  Deprecated APIs of being able to call most methods as
                           class methods or functions instead of object methods
                           have now been deleted;

--- a/lib/Number/Phone.pm
+++ b/lib/Number/Phone.pm
@@ -374,6 +374,10 @@ Return the subscriber part of the number.
 While the superclass implementation returns undef, this is nonsense in just
 about all cases, so you should always implement this.
 
+=item number
+
+Return the unformatted phone number, minus the country code.
+
 =item operator
 
 Return the name of the telco assigned this number, in an appropriate

--- a/lib/Number/Phone/NANP.pm
+++ b/lib/Number/Phone/NANP.pm
@@ -133,6 +133,13 @@ foreach my $method (qw(areacode subscriber)) {
     }
 }
 
+sub number {
+    my $self = shift;
+
+    # skip "+1";
+    return substr $$self, 2;
+}
+
 sub is_geographic {
     my $self = shift;
     # NANP-globals like 1-800 aren't geographic, the rest are
@@ -196,6 +203,11 @@ Return the area code for the number.
 
 Return the name for the area code, if applicable, otherwise returns undef.
 For instance, for a number beginning with +1 201 200 it would return "Jersey City, NJ".
+
+=item number
+
+Return the raw unformatted phone number.  This is the same as the areacode and
+subscriber number joined togehter.
 
 =item subscriber
 

--- a/lib/Number/Phone/StubCountry.pm
+++ b/lib/Number/Phone/StubCountry.pm
@@ -64,4 +64,8 @@ sub format {
   return '+'.$self->country_code().' '.$number;
 }
 
+sub number {
+    shift->{number};
+}
+
 1;

--- a/lib/Number/Phone/UK.pm
+++ b/lib/Number/Phone/UK.pm
@@ -287,6 +287,18 @@ sub location {
     return undef;
 }
 
+=item number
+
+Return the raw unformatted number.  That is, the number minus the country code.
+
+=cut
+
+sub number {
+    my $self = shift;
+    # skip '+44'
+    return substr $$self, 3;
+}
+
 =item subscriber
 
 Return the subscriber part of the number

--- a/t/43-number-method.t
+++ b/t/43-number-method.t
@@ -1,0 +1,24 @@
+#!/usr/bin/perl -w
+
+use strict;
+use lib 't/inc';
+use fatalwarnings;
+
+use Number::Phone;
+use Test::More;
+
+END { done_testing(); }
+
+# number() is implemented in UK, NANP, and StubCountry, so we test each of
+# those.
+
+my %tests = (
+    '+442 0 8771 2924' => '2087712924',   # UK
+    '+1 202 418 1440'  => '2024181440',   # NANP::US
+    '+44 762 437 6698' => '7624376698'    # StubCountry::IM
+);
+
+while (my ($num, $expect) = each %tests) {
+    my $number = new_ok 'Number::Phone', [$num];
+    is $number->number, $expect;
+}


### PR DESCRIPTION
This method returns the raw unformatted phone number, minus the
country code.  This is the same as $self->{number} for a StubCountry
object, or, the value of $$self with the country code removed for
UK/NANP numbers.