### PR TITLE
Support CentOS 7 (and under)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,18 @@ WriteMakefile(
         }
     },
   VERSION_FROM => 'lib/Number/Phone.pm',
+  BUILD_REQUIRES => {
+    'ExtUtils::MakeMaker' => 6.52,
+    'ExtUtils::Manifest'  => 0,
+    'ExtUtlls::Install'   => 0,
+  },
+
+  CONFIGURE_REQUIRES => {
+    'ExtUtils::MakeMaker' => 6.52,
+    'ExtUtils::Manifest'  => 0,
+    'ExtUtlls::Install'   => 0,
+  },
+
   PREREQ_PM    => {
     'Scalar::Util'  => 0,
     'Test::More'    => '0.96', # need done_testing (0.88) and subtests (0.95_01)


### PR DESCRIPTION
CentOS 7 can carry a Perl 5.10.1 without ExtUtils::Manifest or
ExtUtils::Install, even though they are core.
This means that the library will not build by default. Adding these
would have been enough, except they need to be under build/configure
and that was only added in EUMM 6.52, so we're adding that as the
minimum version as well.