### PR TITLE
Add libphonenumber 'format' field support.

### DIFF
--- a/build-data.stubs
+++ b/build-data.stubs
@@ -183,16 +183,17 @@ sub formats_for {
     # see https://github.com/DrHyde/perl-modules-Number-Phone/issues/7
     my $leading_digit_pattern = ($number_format->find('leadingDigits')->get_nodelist())[-1];
     my $formatter = ''.$number_format->find('format');
+    my $formatter_intl = ''.$number_format->find('intlFormat');
 
     if($leading_digit_pattern) {
       ($leading_digit_pattern = $leading_digit_pattern->string_value()); # =~ s/\s//g;
-      push @formatters, {
-        leading_digits => $leading_digit_pattern,
-        pattern        => $number_format_pattern
-      };
-    } else {
-      push @formatters, { pattern => $number_format_pattern };
     }
+    push @formatters, {
+      $leading_digit_pattern ? (leading_digits => $leading_digit_pattern) : (),
+      format => $formatter,
+      $formatter_intl ? (intl_format => $formatter_intl) : (),
+      pattern => $number_format_pattern
+    };
   }
   return @formatters;
 

--- a/lib/Number/Phone.pm
+++ b/lib/Number/Phone.pm
@@ -92,7 +92,7 @@ sub format_using {
 
     eval "use Number::Phone::Formatter::$format";
     die("Couldn't load format '$format': $@\n") if($@);
-    return "Number::Phone::Formatter::$format"->format($self->format());
+    return "Number::Phone::Formatter::$format"->format($self->format(), $self);
 
 }
 

--- a/lib/Number/Phone/Formatter/NationallyPreferred.pm
+++ b/lib/Number/Phone/Formatter/NationallyPreferred.pm
@@ -1,0 +1,63 @@
+package Number::Phone::Formatter::NationallyPreferred;
+
+use strict;
+use warnings;
+use Scalar::Util qw(reftype);
+
+sub _regex_variable {
+    my ($var, $qr, $subs) = @_;
+    $subs =~ s/"/\\"/;
+    $subs = "\"$subs\"";
+    $var =~ s/$qr/$subs/xee;
+    return $var;
+}
+
+sub format {
+    my ($class, $number, $object) = @_;
+
+    # Only care about the ones that will have the formatters stored
+    return $number unless reftype $object eq 'HASH';
+
+    # Don't care about passed in $number in that case
+    $number = $object->{number};
+    foreach my $formatter (@{$object->{formatters}}) {
+        my ($leading_digits, $pattern) = map { $formatter->{$_} } qw(leading_digits pattern);
+        if ((!$leading_digits || $number =~ /^($leading_digits)/x) && $number =~ /^$pattern$/x) {
+            my $format = $formatter->{intl_format} || $formatter->{format};
+            $number = _regex_variable($number, qr/^$pattern$/, $format);
+            return '+' . $object->country_code() . ' ' . $number;
+        }
+    }
+    return '+' . $object->country_code() . ' ' . $number;
+}
+
+1;
+
+=head1 NAME
+
+Number::Phone::Formatter::NationallyPreferred - formatter for nationally-preferred international phone number
+
+=head1 DESCRIPTION
+
+A formatter to output the international number in its nationally preferred format.
+
+=head1 METHOD
+
+=head2 format
+
+This is the only method. It takes an E.123 international format string and a Number::Phone object,
+and outputs the nationally-preferred international phone number using any supplied formatters.
+
+  +1 212 334 0611 -> +1 212-334-0611
+
+=head1 AUTHOR, COPYRIGHT and LICENCE
+
+Copyright 2018 Matthew Somerville E<lt>F<matthew-github@dracos.co.uk>E<gt>
+
+This software is free-as-in-speech software, and may be used,
+distributed, and modified under the terms of either the GNU
+General Public Licence version 2 or the Artistic Licence.  It's
+up to you which one you use.  The full text of the licences can
+be found in the files GPL2.txt and ARTISTIC.txt, respectively.
+
+=cut

--- a/t/formatters.t
+++ b/t/formatters.t
@@ -5,6 +5,7 @@ use lib 't/inc';
 use fatalwarnings;
 
 use Number::Phone;
+use Number::Phone::Lib;
 use Test::More;
 use Scalar::Util qw(blessed);
 
@@ -27,6 +28,13 @@ is(
     Number::Phone->new('+44 20 8771 2924')->format_using('E123'),
     '+44 20 8771 2924',
     "format_using('E123') works too"
+);
+
+note("format_using('NationallyPreferred')");
+is(
+    Number::Phone::Lib->new('+1 202 418 1440')->format_using('NationallyPreferred'),
+    '+1 202-418-1440',
+    "format_using('NationallyPreferred') works too"
 );
 
 note("format_using('non-existent formatter')");


### PR DESCRIPTION
This stores the format/intlFormat given for each libphonenumber formatter in the stub country files, and adds a new NationallyPreferred formatter to use that infomation.

Fixes #78.
  