### PR TITLE
Support nationalPrefix ForParsing/TransformRule.

### DIFF
--- a/build-data.stubs
+++ b/build-data.stubs
@@ -39,7 +39,8 @@ my @gb_formats = formats_for($xml->find(
 
 TERRITORY: foreach my $territory (@territories) {
   my $IDD_country_code = ''.$territory->find('@countryCode');
-  my $national_code    = ''.$territory->find('@nationalPrefix');
+  my $national_code = ''.$territory->find('@nationalPrefixForParsing') || ''.$territory->find('@nationalPrefix');
+  my $national_prefix_transform_rule = ''.$territory->find('@nationalPrefixTransformRule');
 
   my $ISO_country_code = ''.$territory->find('@id');
   if($ISO_country_code !~ /^..$/) {
@@ -110,9 +111,15 @@ TERRITORY: foreach my $territory (@territories) {
   ";
 
   if ($national_code ne '' && $IDD_country_code ne '1') {
+    $national_code =~ s/\s+//g;
+    # Suppressing the warning below is for if the national code optionally
+    # matches part of the number that would then be in the transform rule
     print $module_fh "
       return \$self if (\$self->is_valid());
-      \$number =~ s/(^$national_code)//g;
+      {
+        no warnings 'uninitialized';
+        \$number =~ s/^(?:$national_code)/$national_prefix_transform_rule/;
+      }
       \$self = bless({ number => \$number, formatters => \$formatters, validators => \$validators, ".
       (($IDD_country_code != 1 && -e $codesfile) ? 'areanames => \\%areanames' : '')
       ."}, \$class);

--- a/build-tests.pl
+++ b/build-tests.pl
@@ -22,7 +22,6 @@ my @tests = ();
 
 TERRITORY: foreach my $territory (@territories) {
   my $IDD_country_code = ''.$territory->find('@countryCode');
-  my $national_code    = ''.($IDD_country_code != 1 ? $territory->find('@nationalPrefix') : '');
   my $ISO_country_code = ''.$territory->find('@id');
   if($ISO_country_code !~ /^..$/) {
     # warn("skipping 'country' $ISO_country_code (+$IDD_country_code)\n");
@@ -40,7 +39,7 @@ TERRITORY: foreach my $territory (@territories) {
           ($_->[0] eq 'GB') ? ($_, ['UK', $_->[1]]) : $_
       } (
           [$ISO_country_code, "+$IDD_country_code$number"],
-          [$ISO_country_code, "$national_code$number"],
+          [$ISO_country_code, $number],
           [                   "+$IDD_country_code$number"]
       );
       TUPLE: foreach my $test_tuple (@test_tuples) {

--- a/t/country-test-br.t
+++ b/t/country-test-br.t
@@ -13,3 +13,6 @@ END { done_testing(); }
 # Mobile Number
 is(Number::Phone::Lib->new("+55 35 9 98 70 56 56")->is_mobile(), 1, "+55 35 turned into +55 35 9");
 is(Number::Phone::Lib->new("+55 35   98 70 56 56")->is_mobile(), 1, "old format still works (according to Google anyway)");
+
+isa_ok(Number::Phone::Lib->new("BR", "08522222222"), 'Number::Phone::StubCountry::BR', '0 85 NNNN valid');
+isa_ok(Number::Phone::Lib->new("BR", "0318522222222"), 'Number::Phone::StubCountry::BR', '0 31 85 NNNN valid');

--- a/t/libphonenumber.t
+++ b/t/libphonenumber.t
@@ -80,6 +80,11 @@ isa_ok($CLASS->new('GB', '020 8771 2924'), 'Number::Phone::StubCountry::GB', "N:
 isa_ok($CLASS->new('UK', '020 8771 2924'), 'Number::Phone::StubCountry::GB', "N::P::Lib->new('UK', '0NNNNN')");
 isa_ok($CLASS->new('GB', '20 8771 2924'), 'Number::Phone::StubCountry::GB', "N::P::Lib->new('GB', 'NNNNN')");
 
+note('National prefix issues');
+
+is($CLASS->new("CO", "03211234567"), undef, 'N::P::Lib->new("CO", "03 21 NNNN") invalid');
+isa_ok($CLASS->new("CO", "033211234567"), 'Number::Phone::StubCountry::CO','N::P::Lib->new("CO", "03 321 NNNN") valid');
+
 # switch N::P::C into "UK mode", make sure that N::P::Lib still DTRT
 eval "use Number::Phone::Country qw(uk noexport)";
 isa_ok($CLASS->new('GB', '020 8771 2924'), 'Number::Phone::StubCountry::GB', "N::P::Lib->new('GB', '0NNNNN') with N::P::C in 'uk mode'");


### PR DESCRIPTION
This additional functionality means that e.g.:

* Brazil's (0xx85) 2222-2222 is parsed to +55 85 2222-2222;
* Colombia's 03-321-123-4567 is parsed to +57 321 1234567;
* The invalid 0-321-123-4567 is not parsed as a Colombian number (the auto-generated tests were testing this number).

Fixes #77