### PR TITLE
 Add national formatting of numbers.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -75,6 +75,8 @@ t/country-test-at.t
 t/number-phone-country-multiple.t
 t/country-test-br.t
 t/formatters.t
+lib/Number/Phone/Formatter.pm
+lib/Number/Phone/Formatter/National.pm
 lib/Number/Phone/Formatter/Raw.pm
 lib/Number/Phone/Formatters.pod
 t/number-phone-country-warnings.t

--- a/build-data.stubs
+++ b/build-data.stubs
@@ -174,6 +174,9 @@ sub formats_for {
     $ccode && $ccode =~ /^(IM|JE|GG)$/
   );
 
+  my $national_code = ''.$territory->find('@nationalPrefix');
+  my $territory_national_rule = ''.$territory->find('@nationalPrefixFormattingRule');
+
   my @number_formats = $territory->find('availableFormats/numberFormat')->get_nodelist();
 
   my @formatters = ();
@@ -185,11 +188,16 @@ sub formats_for {
     my $formatter = ''.$number_format->find('format');
     my $formatter_intl = ''.$number_format->find('intlFormat');
 
+    my $national_rule = ''.$number_format->find('@nationalPrefixFormattingRule') || $territory_national_rule;
+    $national_rule =~ s/\$NP/$national_code/;
+    $national_rule =~ s/\$FG/\$1/;
+
     if($leading_digit_pattern) {
       ($leading_digit_pattern = $leading_digit_pattern->string_value()); # =~ s/\s//g;
     }
     push @formatters, {
       $leading_digit_pattern ? (leading_digits => $leading_digit_pattern) : (),
+      $national_rule ? (national_rule => $national_rule) : (),
       format => $formatter,
       $formatter_intl ? (intl_format => $formatter_intl) : (),
       pattern => $number_format_pattern

--- a/lib/Number/Phone/Formatter.pm
+++ b/lib/Number/Phone/Formatter.pm
@@ -1,0 +1,60 @@
+package Number::Phone::Formatter;
+
+use strict;
+use warnings;
+
+sub _regex_variable {
+    my ($var, $qr, $subs) = @_;
+    $subs =~ s/"/\\"/;
+    $subs = "\"$subs\"";
+    $var =~ s/$qr/$subs/xee;
+    return $var;
+}
+
+sub _maybe_add_country {
+    my ($object, $number, $national) = @_;
+    $number = '+' . $object->country_code() . ' ' . $number unless $national;
+    return $number;
+}
+
+sub _format {
+    my ($class, $object, $national) = @_;
+
+    my $number = $object->{number};
+    foreach my $formatter (@{$object->{formatters}}) {
+        my ($leading_digits, $pattern) = map { $formatter->{$_} } qw(leading_digits pattern);
+        if ((!$leading_digits || $number =~ /^($leading_digits)/x) && $number =~ /^$pattern$/x) {
+            my $format;
+            if ($national && $formatter->{national_rule}) {
+                $format = _regex_variable($formatter->{format}, qr/(\$\d)/, $formatter->{national_rule});
+            } else {
+                $format = $formatter->{intl_format} || $formatter->{format};
+            }
+            $number = _regex_variable($number, qr/^$pattern$/, $format);
+            return _maybe_add_country($object, $number, $national);
+        }
+    }
+    return _maybe_add_country($object, $number, $national);
+}
+
+1;
+
+=head1 NAME
+
+Number::Phone::Formatter - base class for other formatters
+
+=head1 DESCRIPTION
+
+A base class containing utility functions used by the formatters.
+
+=head1 AUTHOR, COPYRIGHT and LICENCE
+
+Copyright 2018 Matthew Somerville E<lt>F<matthew-github@dracos.co.uk>E<gt>
+
+This software is free-as-in-speech software, and may be used,
+distributed, and modified under the terms of either the GNU
+General Public Licence version 2 or the Artistic Licence.  It's
+up to you which one you use.  The full text of the licences can
+be found in the files GPL2.txt and ARTISTIC.txt, respectively.
+
+=cut

--- a/lib/Number/Phone/Formatter/National.pm
+++ b/lib/Number/Phone/Formatter/National.pm
@@ -1,4 +1,4 @@
-package Number::Phone::Formatter::NationallyPreferred;
+package Number::Phone::Formatter::National;
 
 use strict;
 use warnings;
@@ -11,27 +11,27 @@ sub format {
     # Only care about the ones that will have the formatters stored
     return $number unless reftype $object eq 'HASH';
 
-    $class->_format($object, 0);
+    $class->_format($object, 1);
 }
 
 1;
 
 =head1 NAME
 
-Number::Phone::Formatter::NationallyPreferred - formatter for nationally-preferred international phone number
+Number::Phone::Formatter::National - formatter for nationally-formatted phone number
 
 =head1 DESCRIPTION
 
-A formatter to output the international number in its nationally preferred format.
+A formatter to output the number in its national format.
 
 =head1 METHOD
 
 =head2 format
 
 This is the only method. It takes an E.123 international format string and a Number::Phone object,
-and outputs the nationally-preferred international phone number using any supplied formatters.
+and outputs the nationally-formatted number using any supplied formatters.
 
-  +1 212 334 0611 -> +1 212-334-0611
+  +1 212 334 0611 -> 212-334-0611
 
 =head1 AUTHOR, COPYRIGHT and LICENCE
 

--- a/lib/Number/Phone/StubCountry.pm
+++ b/lib/Number/Phone/StubCountry.pm
@@ -7,6 +7,16 @@ use Number::Phone::Country qw(noexport);
 use base qw(Number::Phone);
 our $VERSION = '1.3';
 
+=head1 NAME
+
+Number::Phone::StubCountry - Base class for auto-generated country files
+
+=head1 METHODS
+
+=over 4
+
+=cut
+
 sub country_code {
     my $self = shift;
     
@@ -72,5 +82,27 @@ sub format {
   }
   return '+'.$self->country_code().' '.$number;
 }
+
+=item format_for_country
+
+Given a country code (either two-letter ISO or numeric prefix), return the
+number formatted either nationally-formatted, if the number is in the same
+country, or as a nationally-preferred international number if not.
+
+=cut
+
+sub format_for_country {
+  my $self = shift;
+  my $country_code = shift || '';
+  $country_code = Number::Phone::Country::country_code($country_code)
+    if $country_code && $country_code =~ /[a-z]/i;
+  $country_code =~ s/^\+//;
+  return $self->format_using('National') if $country_code eq $self->country_code();
+  return $self->format_using('NationallyPreferred');
+}
+
+=back
+
+=cut
 
 1;

--- a/t/stubs.t
+++ b/t/stubs.t
@@ -33,6 +33,18 @@ is($nl_obj->format(), '+31 20 123 4567', 'Number::Phone->new("NL", "0201234567")
 is(Number::Phone->new("NL", "2"),    undef, "number too short? undef");
 is(Number::Phone->new("NL", "02"),   undef, "number too short? undef");
 
+note("National formatting");
+
+my $ar_obj = Number::Phone->new('AR', '+54 9 11 1234 5678');
+is($ar_obj->format_using('National'), '011 15-1234-5678', 'AR national formatting includes 0, 15, lacks 9');
+is($ar_obj->format_for_country('AR'), '011 15-1234-5678', 'AR argument treated same as national');
+is($ar_obj->format_for_country('+54'), '011 15-1234-5678', '+54 argument treated same as national');
+is($ar_obj->format_using('NationallyPreferred'), '+54 9 11 1234-5678', 'AR international formatting includes +54, 9, lacks 15');
+is($ar_obj->format_for_country('GB'), '+54 9 11 1234-5678', 'GB argument treated same as international');
+is($ar_obj->format_for_country('+44'), '+54 9 11 1234-5678', '+44 argument treated same as international');
+my $dk_obj = Number::Phone->new("DK", "+45 38123456");
+is($dk_obj->format_using('National'), '38 12 34 56', 'DK national formatting has no prefix');
+
 use lib 't/lib';
 
 require 'common-stub_and_libphonenumber_tests.pl';


### PR DESCRIPTION
This adds a new National formatter that outputs the number in national format, using stored nationalPrefixFormattingRule to work out what to display.

It also adds a `format_for_country` function that will then return national format if in same country, international otherwise.

As well as standard usage such as being able to show UK numbers as 020...., one important example is Argentina, where the international number `+54 9 11 1234-5678` is the national number `011 15-1234-5678` (9 removed, 15 is added between area code and local code).

(This builds upon #80, with one commit on top of that PR.) Fixes #79.
 