### PR TITLE
If fixed_line/mobile validators same, is either.

### DIFF
--- a/build-data.stubs
+++ b/build-data.stubs
@@ -75,6 +75,11 @@ TERRITORY: foreach my $territory (@territories) {
           delete $validators->{mobile};
       }
   }
+  # Similarly to +1, don't pass is_mobile or is_fixed_line if could be either
+  if ($validators->{fixed_line} && $validators->{fixed_line} eq $validators->{mobile}) {
+      delete $validators->{fixed_line};
+      delete $validators->{mobile};
+  }
   print $module_fh 'my '.Data::Dumper->new([$validators], [qw(validators)])->Dump();
   my $codesfile = "libphonenumber/resources/geocoding/en/$IDD_country_code.txt";
   if($IDD_country_code == 1) {

--- a/build-tests.pl
+++ b/build-tests.pl
@@ -71,6 +71,14 @@ TERRITORY: foreach my $territory (@territories) {
              }
           }
 
+          if(($IDD_country_code == 45 || $IDD_country_code == 56) && $test_method =~ /
+              is_mobile |
+              is_fixed_line
+          /x) {
+              warnonce("checking $ISO_country_code number +$IDD_country_code $number, as is_geographic *or* $test_method\n");
+              $test_method = [$test_method, 'is_geographic'];
+          }
+
           if($IDD_country_code eq '44' && $number =~ /
               ^
               121 234 5678


### PR DESCRIPTION
This matches libphonenumber behaviour of using FIXED_LINE_OR_MOBILE in
such a circumstance, and matches the existing behaviour with US numbers.

Fixes #84.