### PR TITLE
Add new BS uan number format.

### DIFF
--- a/lib/Number/Phone/NANP.pm
+++ b/lib/Number/Phone/NANP.pm
@@ -219,7 +219,8 @@ sub is_specialrate {
         ^(\+1)?
         (
             900 |                          # NANP-global
-            246 ( 292 | 41[7-9] | 43[01] ) # BB-specific, apparently
+            242225[0-46-9] |               # BS-specific
+            246 ( 292 | 367 | 41[7-9] | 43[01] | 444 | 467 | 736 ) # BB-specific, apparently
         )
     /x) { return 1; }
      else { return 0; }


### PR DESCRIPTION
This was added in libphonenumber 8.8.4, and without it three of the
auto-generated tests fail. Also update the BB line to match the current
libphonenumber regex.