### PR TITLE
Fix application of national prefix transform rule

### DIFF
--- a/build-data.stubs
+++ b/build-data.stubs
@@ -119,19 +119,43 @@ TERRITORY: foreach my $territory (@territories) {
     $national_code =~ s/\s+//g;
     # Suppressing the warning below is for if the national code optionally
     # matches part of the number that would then be in the transform rule
-    print $module_fh "
-      return \$self if (\$self->is_valid());
-      {
-        no warnings 'uninitialized';
-        \$number =~ s/^(?:$national_code)/$national_prefix_transform_rule/;
-      }
-      \$self = bless({ number => \$number, formatters => \$formatters, validators => \$validators, ".
+    my @code = "return \$self if (\$self->is_valid());";
+
+    if ($national_prefix_transform_rule eq '') {
+      # There is no national prefix transform rule, so just delete the national
+      # prefix, if present.
+      push @code, "  \$number =~ s/^(?:$national_code)//;";
+    }
+    else {
+      # There is a national prefix transform rule.
+      push @code,
+        "  my \$prefix = qr/^(?:$national_code)/;",
+        "  my \@matches = \$number =~ /\$prefix/;",
+        "  if (defined \$matches[-1]) {",
+        # We have a match in the last capturing group.  Assume that the
+        # transform rule can be applied.
+        "    no warnings 'uninitialized';",
+        "    \$number =~ s/\$prefix/$national_prefix_transform_rule/;",
+        "  }",
+        "  else {",
+        # We don't have a match in the last capturing group.  Assume that the
+        # transform rule cannot be applied, and instead, just delete the
+        # national prefix, if present.
+        "    \$number =~ s/\$prefix//;",
+        "  }";
+    }
+
+    push @code,
+      "  \$self = bless({ number => \$number, formatters => \$formatters, validators => \$validators, ".
       (($IDD_country_code != 1 && -e $codesfile) ? 'areanames => \\%areanames' : '')
-      ."}, \$class);
-    ";
+      ."}, \$class);";
+
+    print $module_fh join "\n", map {"    $_"} @code;
+    print $module_fh "\n";
   }
-  print $module_fh "return \$self->is_valid() ? \$self : undef;\n";
-  print $module_fh "}\n1;";
+
+  print $module_fh "      return \$self->is_valid() ? \$self : undef;\n";
+  print $module_fh "    }\n1;";
 }
 
 sub preamble {

--- a/t/country-test-ar.t
+++ b/t/country-test-ar.t
@@ -1,0 +1,40 @@
+#!/usr/bin/perl -w
+
+use strict;
+
+use lib 't/inc';
+use fatalwarnings;
+
+use Number::Phone::Lib;
+use Test::More;
+
+END { done_testing(); }
+
+{
+    my $np = Number::Phone::Lib->new('AR', '3715 65 4320');
+    ok($np->is_fixed_line, '3715 65 4320 is a fixed line without national prefix...');
+    ok(!$np->is_mobile, '...it is not a mobile...');
+    is($np->format, '+54 3715 65 4320', '...its international format is correct');
+    is($np->format_using('National'), '03715 65-4320', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('AR', '0 3715 65 4320');
+    ok($np->is_fixed_line, '03715 65 4320 is a fixed line with a national prefix...');
+    ok(!$np->is_mobile, '...it is not a mobile...');
+    is($np->format, '+54 3715 65 4320', '...its international format is correct');
+    is($np->format_using('National'), '03715 65-4320', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('AR', '3715 15 65 4320');
+    ok($np->is_mobile, '3715 15 65 4320 is a mobile with a national prefix...');
+    ok(!$np->is_fixed_line, '...it is not a fixed line...');
+    is($np->format, '+54 9 3715 65 4320', '...its international format is correct');
+    is($np->format_using('National'), '03715 15-65-4320', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('AR', '0 3715 15 65 4320');
+    ok($np->is_mobile, '03715 15 65 4320 is a mobile with a national prefix...');
+    ok(!$np->is_fixed_line, '...it is not a fixed line...');
+    is($np->format, '+54 9 3715 65 4320', '...its international format is correct');
+    is($np->format_using('National'), '03715 15-65-4320', '...as is its national format');
+}

--- a/t/country-test-br.t
+++ b/t/country-test-br.t
@@ -10,10 +10,31 @@ use Test::More;
 
 END { done_testing(); }
 
-# Mobile Number
-is(Number::Phone::Lib->new("+55 35 9 98 70 56 56")->is_mobile(), 1, "+55 35 turned into +55 35 9");
-is(Number::Phone::Lib->new("+55 35   98 70 56 56")->is_mobile(), 1, "old format still works (according to Google anyway)");
-
-# ignore carrier select prefixes when parsing a local number
-is(Number::Phone::Lib->new("BR", "08522222222")->format(), '+55 85 2222 2222', '085 NNNN parsed ok');
-is(Number::Phone::Lib->new("BR", "0318522222222")->format(), '+55 85 2222 2222', '0 31 85 NNNN parsed ok');
+{
+    my $np = Number::Phone::Lib->new('BR', '0 85 2222 2222');
+    ok($np->is_fixed_line, '0 85 2222 2222 is a fixed line without carrier select code...');
+    ok(!$np->is_mobile, '...it is not a mobile...');
+    is($np->format, '+55 85 2222 2222', '...its international format is correct');
+    is($np->format_using('National'), '(85) 2222-2222', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('BR', '0 31 85 2222 2222');
+    ok($np->is_fixed_line, '0 31 85 2222 2222 is a fixed line with carrier select code...');
+    ok(!$np->is_mobile, '...it is not a mobile...');
+    is($np->format, '+55 85 2222 2222', '...its international format is correct');
+    is($np->format_using('National'), '(85) 2222-2222', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('BR', '35 9 98 70 56 56');
+    ok($np->is_mobile, '35 9 98 70 56 56 is a new style 9 digit mobile with area code...');
+    ok(!$np->is_fixed_line, '...it is not a fixed line...');
+    is($np->format, '+55 35 99870 5656', '...its international format is correct');
+    is($np->format_using('National'), '(35) 99870-5656', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('BR', '35 98 70 56 56');
+    ok($np->is_mobile, '35 9 98 70 56 56 is an old style 8 digit mobile with area code...');
+    ok(!$np->is_fixed_line, '...it is not a fixed line...');
+    is($np->format, '+55 35 9870 5656', '...its international format is correct');
+    is($np->format_using('National'), '(35) 9870-5656', '...as is its national format');
+}

--- a/t/country-test-mx.t
+++ b/t/country-test-mx.t
@@ -1,0 +1,44 @@
+#!/usr/bin/perl -w
+
+use strict;
+
+use lib 't/inc';
+use fatalwarnings;
+
+use Number::Phone::Lib;
+use Test::More;
+
+END { done_testing(); }
+
+{
+    my $np = Number::Phone::Lib->new('MX', '81 1234 5678');
+    ok($np->is_fixed_line, '81 1234 5678 is a fixed line without national prefix...');
+    ok(!$np->is_mobile, '...it is not a mobile...');
+    is($np->format, '+52 81 1234 5678', '...its international format is correct');
+    is($np->format_using('National'), '01 81 1234 5678', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('MX', '01 81 1234 5678');
+    ok($np->is_fixed_line, '01 81 1234 5678 is a fixed line with domestic dialling prefix...');
+    ok(!$np->is_mobile, '...it is not a mobile...');
+    is($np->format, '+52 81 1234 5678', '...its international format is correct');
+    is($np->format_using('National'), '01 81 1234 5678', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('MX', '044 81 1234 5678');
+    ok($np->is_mobile, '044 81 1234 5678 is a local mobile as called from a fixed line...');
+    ok(!$np->is_fixed_line, '...it is not a fixed line...');
+    is($np->format, '+52 1 81 1234 5678', '...its international format is correct');
+    is($np->format_using('National'), '044 81 1234 5678', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('MX', '045 81 1234 5678');
+    ok($np->is_mobile, '045 81 1234 5678 is a domestic mobile as called from a fixed line...');
+    ok(!$np->is_fixed_line, '...it is not a fixed line...');
+    is($np->format, '+52 1 81 1234 5678', '...its international format is correct');
+    # 045 is the prefix used when dialling a mobile number from a fix line,
+    # where the mobile and the fixed line share the same area code.  045 is
+    # the code used when the area codes differ.  The area code of the caller is
+    # not known, so libphonenumber always uses 044.
+    is($np->format_using('National'), '044 81 1234 5678', '...as is its national format (045 becomes 044)');
+}

--- a/t/country-test-sm.t
+++ b/t/country-test-sm.t
@@ -1,0 +1,37 @@
+#!/usr/bin/perl -w
+
+use strict;
+
+use lib 't/inc';
+use fatalwarnings;
+
+use Number::Phone::Lib;
+use Test::More;
+
+END { done_testing(); }
+
+{
+    my $np = Number::Phone::Lib->new('SM', '912345');
+    ok($np->is_fixed_line, '912345 is a fixed line without the 0549 prefix...');
+    ok(!$np->is_mobile, '...it is not a mobile...');
+    is($np->format, '+378 0549 912345', '...its international format is correct');
+    is($np->format_using('National'), '(0549) 912345', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('SM', '0549 912345');
+    ok($np->is_fixed_line, '0549 912345 is a fixed line without the 0549 prefix...');
+    ok(!$np->is_mobile, '...it is not a mobile...');
+    is($np->format, '+378 0549 912345', '...its international format is correct');
+    is($np->format_using('National'), '(0549) 912345', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('SM', '66661212');
+    ok($np->is_mobile, '044 81 1234 5678 is a mobile...');
+    ok(!$np->is_fixed_line, '...it is not a fixed line...');
+    is($np->format, '+378 66 66 12 12', '...its international format is correct');
+    is($np->format_using('National'), '66 66 12 12', '...as is its national format');
+}
+{
+    my $np = Number::Phone::Lib->new('MX', '0549 66661212');
+    ok(!defined $np, '0549 66661212 is a mobile with the 0549 prefix, which is not valid');
+}


### PR DESCRIPTION
libphonenumber only applies the national prefix transform rule if the last possible capture group of the national prefix rule regex matches. That is, it won't apply the transform rule if there are no prefixes to transform.  Where there are no suitable captures, it will simply delete the matching prefix.  See:

[com.google.i18n.phonenumbers.maybeStripNationalPrefixAndCarrierCode()](https://github.com/googlei18n/libphonenumber/blob/8a189c561bc343b2b0d058523ca263b73e157928/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java#L2886)

The Number::Phone country stub files, however, always apply the transform rule.  This can lead to cases where phone numbers are incorrectly converted to the wrong type.  For example, the international format for Argentinian mobile numbers requires the trunk code 0 to be removed, 9 to be placed before the area code, and the mobile prefix 15 to be removed, so:

    "0 3715 15 65 4320" => "+54 9 3715 65 4320"

But Number::Phone incorrectly does the same for fixed line numbers:

    "0 3715 65 4320" => "+54 9 3715 65 4320"

It should be:

    "0 3715 65 4320" => "+54 3715 65 4320"

This branch makes the Number::Phone country stub classes more closely follow the logic in libphonenumber.