### PR TITLE
Make handling of UK country code consistent between Number::Phone::UK and Number::Phone::Lib

### DIFF
--- a/lib/Number/Phone/UK.pm
+++ b/lib/Number/Phone/UK.pm
@@ -90,6 +90,7 @@ sub _clean_number {
     my $clean = shift;
     $clean =~ s/[^0-9+]//g;               # strip non-digits/plusses
     $clean =~ s/^\+44//;                  # remove leading +44
+    $clean =~ s/^[+]+//;                  # remove leading +
     $clean =~ s/^0//;                     # kill leading zero
     return $clean;
 }

--- a/t/country-test-uk.t
+++ b/t/country-test-uk.t
@@ -1,0 +1,63 @@
+#!/usr/bin/perl -w
+
+use strict;
+
+use lib 't/inc';
+use fatalwarnings;
+
+use Number::Phone;
+use Number::Phone::Lib;
+use Test::More;
+
+END { done_testing(); }
+
+{
+    my $np  = Number::Phone::Lib->new('UK', '+238 989 12 34');
+    my $int = canonical_format($np);
+    is( $int,
+        '+442389891234',
+        'given "UK" as the country, and a valid UK number that is also a ' .
+        'valid international number for another country, N::P::L returns ' .
+        'a valid UK object'
+    );
+}
+{
+    my $np  = Number::Phone->new('UK', '+238 989 12 34');
+    my $int = canonical_format($np);
+    is( $int,
+        '+442389891234',
+        'given "UK" as the country, and a valid UK number that is also a ' .
+        'valid international number for another country, N::P returns ' .
+        'a valid UK object'
+    );
+}
+{
+    my $np  = Number::Phone::Lib->new('UK', '+238 989 12 3');
+    my $int = canonical_format($np);
+    is( $int,
+        undef,
+        'given "UK" as the country, and an invalid UK number that is also ' .
+        'an invalid international number for another country, N::P::L ' .
+        'returns undef'
+    );
+}
+{
+    my $np  = Number::Phone->new('UK', '+238 989 12 3');
+    my $int = canonical_format($np);
+    is( $int,
+        undef,
+        'given "UK" as the country, and an invalid UK number that is also ' .
+        'an invalid international number for another country, N::P ' .
+        'returns undef'
+    );
+}
+
+sub canonical_format {
+    my $np = shift;
+
+    return undef if !defined $np;
+
+    my $fmt = $np->format;
+    $fmt =~ s/[^0-9+]//g;
+    return $fmt;
+}


### PR DESCRIPTION
When given both an alpha-2 country code, and a number with an international country calling code prefix, the behaviour of Number::Phone::UK and Number::Phone::Lib is inconsistent.

Number::Phone::Lib strips the "+" from the number, causing the alpha-2 country code to take priority.  For example, "+238 989 12 34" is a valid Cape Verde number.  Removing the "+" prefix gives a valid UK number (albeit without the leading zero).  Given "GB" and "+238 989 12 34", Number::Phone::Lib will return a UK object for "+44 23 8989 1234", whereas Number::Phone will return undef, because the number fails the basic UK number length check.

Given "+238 989 12 3", which is an invalid Cape Verde number, and an invalid UK number, Number::Phone::Lib will return undef.  Number::Phone, however, returns a Number::Phone::UK object, which when formatted returns "+44+238989123".

This PR causes Number::Phone::UK to behave in the same way as Number::Phone::Lib.