### PR TITLE
Don't test internal state of string

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -61,7 +61,6 @@ WriteMakefile(
     'Scalar::Util'           => 1.48,
     'Test::Differences'      => 0.62,
     'Test::More'             => '0.96', # need done_testing (0.88) and subtests (0.95_01)
-    'Test::utf8'             => 0,
     'Test::Warnings'         => 0,
   },
   dist => {

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use utf8;
 use lib 't/inc';
 use nptestutils;
 
@@ -7,15 +8,10 @@ use Test::More;
 
 use Number::Phone;
 
-eval 'use Test::utf8';
-
-SKIP: {
-    skip("Test::utf8 not available", 1) if($@);
-
-    is_flagged_utf8(
-        Number::Phone->new("+49 906 1234567")->areaname(),
-        "Donauwörth area name isflagged as UTF-8"
-    );
-};
+is(
+    Number::Phone->new("+49 906 1234567")->areaname(),
+    'Donauwörth',
+    "Donauwörth area name is decoded to Unicode characters"
+);
 
 done_testing();


### PR DESCRIPTION
Test::utf8 is used here to test whether a string returned by the module is upgraded. This is unnecessary and improper. From the original commit (https://github.com/DrHyde/perl-modules-Number-Phone/commit/5305eac06d55d4611a5d730585a0d08049ed1031) it looks like the intent was to test whether the string was returned as decoded Unicode characters, which can be tested with a simple string equality test against the properly decoded string that is expected.

The utf8 flag test is improper for this because it is an implementation detail which is only part of the story. If the string is decoded and then downgraded, it will still contain the correct Unicode characters to any pure-perl code (assuming all of the characters are below U+FF so it can be stored downgraded), so the test failing is incorrect in that case. If the string is not decoded to characters, it can still be upgraded by Perl operations arbitrarily, which will fool this test.

I don't know the context to tell whether an exact string match is an appropriate test here. There's no generic way to test whether a string is decoded characters, because Perl strings contain whatever they are interpreted to contain.