### PR TITLE
Do not destroy `@ARGV` while searching for `--without_uk`.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,8 +11,8 @@ BEGIN {
     shift @INC;
 }
 
-while(@ARGV) {
-    if(shift() eq '--without_uk') {
+foreach my $arg (@ARGV) {
+    if($arg eq '--without_uk') {
         $Number::Phone::BuildTools::without_uk++;
     }
 }


### PR DESCRIPTION
When we destroy `@ARGV` by shifting the values off, we lose any command line arguments that they user may have provided while running `perl Makefile.PL` (e.g. `INSTALLDIRS=...`).

So, rather than shifting the arguments off to search for our custom `--without_uk` argument, just iterate over `@ARGV`.