### PR TITLE
Be able to validate Denmark's mobile numbers

### DIFF
--- a/build-tests.pl
+++ b/build-tests.pl
@@ -82,8 +82,8 @@ TERRITORY: foreach my $territory (@territories) {
              }
           }
 
-          # Denmark and Chile
-          if(($IDD_country_code == 45 || $IDD_country_code == 56) && $test_method =~ /
+          # Chile
+          if($IDD_country_code == 56 && $test_method =~ /
               is_mobile |
               is_fixed_line
           /x) {

--- a/t/stubs.t
+++ b/t/stubs.t
@@ -41,6 +41,10 @@ is($ar_obj->format_for_country('+44'), '+54 9 11 2345-6789', '+44 argument treat
 my $dk_obj = Number::Phone->new("DK", "+45 38123456");
 is($dk_obj->format_using('National'), '38 12 34 56', 'DK national formatting has no prefix');
 
+$dk_obj = Number::Phone->new('DK', '34 20 12 34');
+ok(!$dk_obj->is_fixed_line, "DK mobile range in fixed line segment");
+ok($dk_obj->is_mobile, "... and is indeed mobile");
+
 use lib 't/lib';
 
 require 'common-stub_and_libphonenumber_tests.pl';


### PR DESCRIPTION
Our app has an issue with Danish numbers, which cannot be validated as either fixed line or mobile. This is a minor inconvenience to our users.

The problem is that upstream has fixed lines and mobiles lines defined as the same regexp and Number::Phone strips the checks for is_mobile and is_fixed when these are the same, as found in build-data.stubs and build-tests.pl, introduced by 02f12d42294654dcac700113fef258c6e1a4567c.

I've created an upstream PR to improve the Danish number checks so we in Perl are going to be aware what Denmark's mobile and landline number are. I've ran build-data.sh --force with the data from the PR at Google and the tests in t/stubs.t work as intended.

Only merge after https://github.com/google/libphonenumber/pull/3417 has been merged into the Google code base.