### PR TITLE
Drop Parallel::ForkManager as a requirement

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -41,7 +41,6 @@ WriteMakefile(
     'ExtUtils::Manifest'      => 0,
     'ExtUtils::Install'       => 0,
     'File::ShareDir::Install' => 0.11,
-    'Parallel::ForkManager'   => '0.7.6' # return data from child processes
   },
 
   CONFIGURE_REQUIRES => {


### PR DESCRIPTION
Parallel::ForkManager seems to be used only in t/fork.t, and this distribution is already being tested in platforms where this library is not available, so it is not relaly a requirement.

It could be a recommended library, but it's not clear how to set that in Makefile.PL.